### PR TITLE
Add lobbies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ backend/face-extractor/*.jpeg
 
 # images
 images/
+
+__pycache__

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,7 +1,11 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 import os
+import uuid
+import random
+import string
 from face_extractor.face_extractor import extract_face
+from lobby.lobby_controller import lobby_bp
 
 app = Flask(__name__)
 CORS(app)  # Enable CORS for cross-origin requests
@@ -11,6 +15,8 @@ RAW_FOLDER = os.path.join(IMAGES_FOLDER, 'raw')
 PROCESSED_FOLDER = os.path.join(IMAGES_FOLDER, 'processed')
 app.config['RAW_FOLDER'] = RAW_FOLDER
 app.config['PROCESSED_FOLDER'] = PROCESSED_FOLDER
+
+app.register_blueprint(lobby_bp)
 
 # Ensure the folders exist
 os.makedirs(RAW_FOLDER, exist_ok=True)

--- a/backend/lobby/lobby_controller.py
+++ b/backend/lobby/lobby_controller.py
@@ -74,7 +74,7 @@ def get_all_public_lobbies() -> Tuple[List[Lobby], int]:
     public_lobbies = [
         {code: lobby}
         for code, lobby in lobbies.items()
-        if not lobby["private"]
+        if not lobby['private']
     ]
 
     return jsonify(public_lobbies), 200

--- a/backend/lobby/lobby_controller.py
+++ b/backend/lobby/lobby_controller.py
@@ -13,7 +13,7 @@ lobbies: Dict[str, Lobby] = {}
 def generate_lobby_code(length: int = 6) -> str:
     return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
 
-@lobby_bp.route('/create-lobby', methods=['POST'])
+@lobby_bp.route('/lobbies', methods=['POST'])
 def create_lobby() -> Tuple[CreateLobbyResponse, int]:
     data = request.get_json()
     host_name: Optional[str] = data.get('host_name')
@@ -38,7 +38,7 @@ def create_lobby() -> Tuple[CreateLobbyResponse, int]:
 
     return jsonify({"message": "Lobby created successfully", "lobby_code": lobby_code}), 201
 
-@lobby_bp.route('/join-lobby/<lobby_code>', methods=['POST'])
+@lobby_bp.route('/lobbies/<lobby_code>/join', methods=['POST'])
 def join_lobby(lobby_code: str) -> Tuple[JoinLobbyResponse, int]:
     data = request.get_json()
     user_name: Optional[str] = data.get('username')
@@ -80,7 +80,7 @@ def get_all_public_lobbies() -> Tuple[List[Lobby], int]:
     return jsonify(public_lobbies), 200
 
 # Technically anyone can change anyones username unless we add authentication
-@lobby_bp.route('/lobby/<lobby_code>/user/<user_id>', methods=['PUT'])
+@lobby_bp.route('/lobbies/<lobby_code>/users/<user_id>', methods=['PUT'])
 def change_username(lobby_code: str, user_id: str) -> Tuple[ChangeNameResponse, int]:
     data = request.get_json()
     new_username: Optional[str] = data.get('new_username')

--- a/backend/lobby/lobby_controller.py
+++ b/backend/lobby/lobby_controller.py
@@ -1,0 +1,104 @@
+from flask import Blueprint, request, jsonify
+from typing import Dict, Tuple, Optional
+import uuid
+import random
+import string
+from .lobby_types import *
+
+lobby_bp = Blueprint('lobby', __name__)
+
+# We can replace this with something better when we need it
+lobbies: Dict[str, Lobby] = {}
+
+def generate_lobby_code(length: int = 6) -> str:
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=length))
+
+@lobby_bp.route('/create-lobby', methods=['POST'])
+def create_lobby() -> Tuple[CreateLobbyResponse, int]:
+    data = request.get_json()
+    host_name: Optional[str] = data.get('host_name')
+    private: bool = data.get('private', False)
+    
+    if not host_name:
+        return jsonify({"error": "Host name is required"}), 400
+    
+    lobby_code = generate_lobby_code()
+
+    # Very unlikely to be a clash but just in case
+    while lobby_code in lobbies:
+        lobby_code = generate_lobby_code()
+
+    host_id = str(uuid.uuid4())
+
+    lobbies[lobby_code] = {
+        "host_id": host_id,
+        "players": {host_id: host_name},
+        "private": private
+    }
+
+    return jsonify({"message": "Lobby created successfully", "lobby_code": lobby_code}), 201
+
+@lobby_bp.route('/join-lobby/<lobby_code>', methods=['POST'])
+def join_lobby(lobby_code: str) -> Tuple[JoinLobbyResponse, int]:
+    data = request.get_json()
+    user_name: Optional[str] = data.get('username')
+
+    if not lobby_code or not user_name:
+        return jsonify({"error": "Lobby code and username are required"}), 400
+
+    if lobby_code not in lobbies:
+        return jsonify({"error": "Lobby not found"}), 404
+
+    lobby = lobbies[lobby_code]
+    if user_name in lobby['players'].values():
+        return jsonify({"error": "Username already exists in the lobby"}), 400
+
+    user_id = str(uuid.uuid4())
+
+    lobby['players'][user_id] = user_name
+
+    return jsonify({"message": "Joined lobby successfully"}), 200
+
+@lobby_bp.route('/lobbies/<lobby_code>', methods=['GET'])
+def get_lobby(lobby_code: str) -> Tuple[GetLobbyResponse, int]:
+    if not lobby_code:
+        return jsonify({"error": "Lobby code is required"}), 400
+
+    if lobby_code not in lobbies:
+        return jsonify({"error": "Lobby not found"}), 404
+
+    return jsonify(lobbies[lobby_code]), 200
+
+@lobby_bp.route('/lobbies', methods=['GET'])
+def get_all_public_lobbies() -> Tuple[List[Lobby], int]:
+    public_lobbies = [
+        {code: lobby}
+        for code, lobby in lobbies.items()
+        if not lobby["private"]
+    ]
+
+    return jsonify(public_lobbies), 200
+
+# Technically anyone can change anyones username unless we add authentication
+@lobby_bp.route('/lobby/<lobby_code>/user/<user_id>', methods=['PUT'])
+def change_username(lobby_code: str, user_id: str) -> Tuple[ChangeNameResponse, int]:
+    data = request.get_json()
+    new_username: Optional[str] = data.get('new_username')
+
+    if not lobby_code or not new_username:
+        return jsonify({"error": "Lobby code and new username are required"}), 400
+
+    if lobby_code not in lobbies:
+        return jsonify({"error": "Lobby not found"}), 404
+
+    lobby = lobbies[lobby_code]
+    if user_id not in lobby['players']:
+        return jsonify({"error": "User not found in the lobby"}), 404
+
+    if new_username in lobby['players'].values():
+        return jsonify({"error": "Username already exists in the lobby"}), 400
+
+    lobby['players'][user_id] = new_username
+
+    return jsonify({"message": "Username changed successfully"}), 200
+

--- a/backend/lobby/lobby_types.py
+++ b/backend/lobby/lobby_types.py
@@ -1,0 +1,28 @@
+from typing import Dict, List, Optional, TypedDict
+
+class Player(TypedDict):
+    user_id: str
+    username: str
+
+class Lobby(TypedDict):
+    host_id: str
+    players: Dict[str, str]
+    private: bool
+
+class GetLobbyResponse(TypedDict):
+    lobby_code: str
+    host: str
+    players: List[Player]
+
+class ErrorResponse(TypedDict):
+    error: str
+
+class CreateLobbyResponse(TypedDict):
+    message: str
+    lobby_code: str
+
+class JoinLobbyResponse(TypedDict):
+    message: str
+
+class ChangeNameResponse(TypedDict):
+    message: str


### PR DESCRIPTION
Added endpoints (I don't know if we need all of these yet):
* `POST /lobbies` -> Creates a public or private lobby associated with a host user and returns a lobby_code that other users can use to join the lobby
* `POST /lobbies/<lobby_code>/join` -> Takes a lobby code and assigns the user to that lobby
* `GET /lobbies` -> Returns all **public** lobbies
* `GET /lobbies/<lobby_code>` -> Returns details about a specific lobby
* `PUT /lobbies/<lobby_code>/users/<user_id>` -> Update details about a user (right now `username` is the only thing that can be changed)

https://github.com/user-attachments/assets/acba7a44-f7d6-49ea-a498-0a31787a6000

