### PR TITLE
feat: bind to all network interfaces

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -44,4 +44,4 @@ def upload_file():
         return jsonify({"message": "File uploaded successfully", "file_path": file_path}), 200
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    app.run(debug=True, host="0.0.0.0")

--- a/frontend/config/serverConfig.js
+++ b/frontend/config/serverConfig.js
@@ -1,0 +1,7 @@
+export const api = {
+    host: () => {
+        return `http://${window?.location.hostname || 'localhost'}:5000`
+    }
+}
+
+export default api;

--- a/frontend/scenes/CreateLobbyScene.js
+++ b/frontend/scenes/CreateLobbyScene.js
@@ -1,4 +1,5 @@
 import Phaser from "phaser";
+import {api} from "../config/serverConfig.js";
 
 export default class CreateLobbyScene extends Phaser.Scene {
   constructor() {
@@ -70,7 +71,7 @@ export default class CreateLobbyScene extends Phaser.Scene {
   }
 
   fetchPlayersList() {
-    fetch(`http://localhost:5000/lobbies/${this.lobbyCode}`)
+    fetch(`${api.host()}/lobbies/${this.lobbyCode}`)
       .then(response => response.json())
       .then(data => {
         this.updatePlayersList(data.players);

--- a/frontend/scenes/JoinLobbyScene.js
+++ b/frontend/scenes/JoinLobbyScene.js
@@ -1,4 +1,5 @@
 import Phaser from "phaser";
+import {api} from "../config/serverConfig.js";
 
 export default class JoinLobbyScene extends Phaser.Scene {
   constructor() {
@@ -43,7 +44,7 @@ export default class JoinLobbyScene extends Phaser.Scene {
   }
 
   fetchLobbies() {
-    fetch('http://localhost:5000/lobbies')
+    fetch(`${api.host()}/lobbies`)
       .then(response => response.json())
       .then(lobbies => {
         this.updateLobbiesList(lobbies);
@@ -83,7 +84,7 @@ export default class JoinLobbyScene extends Phaser.Scene {
   }
 
   joinLobby(lobbyCode, playerName) {
-    fetch(`http://localhost:5000/lobbies/${lobbyCode}/join`, {
+    fetch(`${api.host()}/lobbies/${lobbyCode}/join`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/frontend/scenes/StartScene.js
+++ b/frontend/scenes/StartScene.js
@@ -1,4 +1,5 @@
 import Phaser from "phaser";
+import api from "../config/serverConfig.js";
 
 export default class StartScene extends Phaser.Scene {
   constructor() {
@@ -86,7 +87,7 @@ export default class StartScene extends Phaser.Scene {
   }
 
   createLobby(playerName) {
-    fetch("http://localhost:5000/lobbies", {
+    fetch(`${api.host()}/lobbies`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,5 @@
+export default {
+    "server": {
+        "host": "0.0.0.0"
+    }
+}


### PR DESCRIPTION
I've tried to access the client on my phone in order to test, but had problems with references to localhost in frontend code.
This PR makes both frontend and backend bind to 0.0.0.0, so that I can use 192.168.x.x on my phone and access my computer.

For now the assumption is that vite/flast are running on the same domain (just different ports). Of course this needs adjusting the future.